### PR TITLE
chore: switch to semver and use release-please

### DIFF
--- a/.github/release-please.yml
+++ b/.github/release-please.yml
@@ -1,0 +1,1 @@
+releaseType: python

--- a/setup.py
+++ b/setup.py
@@ -16,7 +16,7 @@ import setuptools
 
 name = 'gcp-docuploader'
 description = ''
-version = '2019.06.18'
+version = '0.1.0'
 release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     "click",


### PR DESCRIPTION
It looks like pip will sort the existing versions above the semver ones. 

We can try "yanking" the existing versions https://pypi.org/help/#yanked although I think you need a new-ish pip version for that to be respected.


@tbpg @JustinBeckwith 