### PR TITLE
chore: fix lint with Python3.9 default session

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,7 @@
 
 import nox
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.9"
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):


### PR DESCRIPTION
Locally running it for 3.9 seems to have passed, trying a draft to test it out.

Fixes #85.