### PR TITLE
fix: update storage to v2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     "click",
     "colorlog",
-    "google-cloud-storage<2.0.0dev",
+    "google-cloud-storage<3.0.0dev",
     "protobuf>=3.12.0",
     "six"
 ]


### PR DESCRIPTION
Storage has recently dropped support for Python 2. Attempting to upgrade storage to v2 here as well.

Fixes #96.