### PR TITLE
chore: cleanup references to master

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,4 +39,4 @@ There are two steps for uploading docs:
 `docuploader` can use ADC or a given service account.
 
 For an example of using `docuploader`, see
-[example usage in googleapis/google-cloud-go](https://github.com/googleapis/google-cloud-go/blob/master/internal/kokoro/publish_docs.sh).
+[example usage in googleapis/google-cloud-go](https://github.com/googleapis/google-cloud-go/blob/main/internal/kokoro/publish_docs.sh).

--- a/owlbot.py
+++ b/owlbot.py
@@ -25,9 +25,3 @@ s.move(templated_files / ".kokoro")
 
 s.shell.run(["nox", "-s", "blacken"], hide_output=False)
 
-s.replace(
-  ".kokoro/*",
-  "master",
-  "main"
-)
-


### PR DESCRIPTION
Now that the link is updated, we can omit using reference to `master` on the README as well as fix the references in OwlBot file.

Fixes #83.