### PR TITLE
chore: use templated renovate.json

### DIFF
--- a/owlbot.py
+++ b/owlbot.py
@@ -22,5 +22,6 @@ common = gcp.CommonTemplates()
 # ----------------------------------------------------------------------------
 templated_files = common.py_library()
 s.move(templated_files / ".kokoro")
+s.move(templated_files / "renovate.json")
 
 s.shell.run(["nox", "-s", "generate_protos", "blacken"], hide_output=False)

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,12 @@
+{
+  "extends": [
+    "config:base",
+    "group:all",
+    ":preserveSemverRanges",
+    ":disableDependencyDashboard"
+  ],
+  "ignorePaths": [".pre-commit-config.yaml"],
+  "pip_requirements": {
+    "fileMatch": ["requirements-test.txt", "samples/[\\S/]*constraints.txt", "samples/[\\S/]*constraints-test.txt"]
+  }
+}


### PR DESCRIPTION
This will prevent renovate bot from opening PRs such as https://github.com/googleapis/docuploader/pull/119 for templated files