### PR TITLE
chore: delete duplicate renovate.json

### DIFF
--- a/.github/renovate.json
+++ b/.github/renovate.json
@@ -1,7 +1,0 @@
-{
-  "extends": [
-    "config:base",
-    ":preserveSemverRanges",
-    ":disableDependencyDashboard"
-  ]
-}


### PR DESCRIPTION
Removes `.github/renovate.json` and uses the templated `renovate.json` [here](https://github.com/googleapis/docuploader/blob/main/renovate.json)