### PR TITLE
fix: add clarification on where docs.metadata should be

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,9 @@ There are two steps for uploading docs:
    --credentials TEXT         Path to the credentials file to use for Google
                               Cloud Storage.
 
-   --metadata-file TEXT       Path to the docs.metadata file.
+   --metadata-file TEXT       Path to the docs.metadata file. The path must be
+                              relative to the CWD.
+
    --destination-prefix TEXT  Prefix to include when uploading tar file. A -
                               will be added after the prefix, if there is one.
 

--- a/docuploader/__main__.py
+++ b/docuploader/__main__.py
@@ -92,7 +92,11 @@ def upload(
 
     docuploader.log.info("Loading up your metadata.")
     try:
-        shutil.copy(metadata_path, pathlib.Path(documentation_path) / metadata_file)
+        if documentation_path not in metadata_file:
+            shutil.copy(
+                metadata_path,
+                pathlib.Path(documentation_path) / metadata_file,
+            )
     except shutil.SameFileError:
         pass
 

--- a/docuploader/__main__.py
+++ b/docuploader/__main__.py
@@ -95,14 +95,12 @@ def upload(
     docuploader.log.success("Let's upload some docs!")
 
     docuploader.log.info("Loading up your metadata.")
-    try:
-        if documentation_path not in metadata_file:
-            shutil.copy(
-                metadata_path,
-                pathlib.Path(documentation_path) / metadata_file,
-            )
-    except shutil.SameFileError:
-        pass
+
+    if documentation_path not in metadata_file:
+        shutil.copy(
+            metadata_path,
+            pathlib.Path(documentation_path) / metadata_file,
+        )
 
     metadata = metadata_pb2.Metadata()
     if metadata_file.endswith(".json"):

--- a/docuploader/__main__.py
+++ b/docuploader/__main__.py
@@ -54,7 +54,11 @@ def main():
     default=None,
     help="Path to the credentials file to use for Google Cloud Storage.",
 )
-@click.option("--metadata-file", default=None, help="Path to the docs.metadata file.")
+@click.option(
+    "--metadata-file",
+    default=None,
+    help="Path to the docs.metadata file. The path must be relative to the CWD.",
+)
 @click.option(
     "--destination-prefix",
     default=None,


### PR DESCRIPTION
Adding additional documentation on the fact that `docs.metadata` file should be relevant to the current working directory. 

Fixing a bug where if `docs.metadata` already exists in the output documentation path, we simply ignore that and use that file.

Verified locally that the fix works when `docs.metadata` is already placed in the `documentation_path`.

Fixes #132.