### PR TITLE
fix: prevent empty tarballs from being passed on

### DIFF
--- a/docuploader/__main__.py
+++ b/docuploader/__main__.py
@@ -74,7 +74,7 @@ def upload(
         docuploader.log.error(
             "You need credentials to run this! Use Application Default Credentials or specify --credentials on the command line."
         )
-        return sys.exit(1)
+        sys.exit(1)
 
     if metadata_file is None:
         metadata_file = "docs.metadata"
@@ -87,24 +87,23 @@ def upload(
         docuploader.log.error(
             "You need metadata to upload the docs. You can generate it with docuploader create-metadata"
         )
-        return sys.exit(1)
-
+        sys.exit(1)
     try:
         if not os.listdir(documentation_path):
             docuploader.log.error(
                 f"The documentation path given ({documentation_path}) does not contain any documentation files."
             )
-            return sys.exit(1)
+            sys.exit(1)
     except FileNotFoundError:
         docuploader.log.error(
             f"The documentation path given ({documentation_path}) does not exist relative to CWD."
         )
-        return sys.exit(1)
+        sys.exit(1)
     except NotADirectoryError:
         docuploader.log.error(
             f"The documentation path given ({documentation_path}) is a file not a directory."
         )
-        return sys.exit(1)
+        sys.exit(1)
 
     docuploader.log.success("Let's upload some docs!")
 

--- a/docuploader/__main__.py
+++ b/docuploader/__main__.py
@@ -13,6 +13,7 @@
 # limitations under the License.
 
 import datetime
+import os
 import pathlib
 import shutil
 import sys
@@ -85,6 +86,23 @@ def upload(
     if not metadata_path.exists():
         docuploader.log.error(
             "You need metadata to upload the docs. You can generate it with docuploader create-metadata"
+        )
+        return sys.exit(1)
+
+    try:
+        if not os.listdir(documentation_path):
+            docuploader.log.error(
+                f"The documentation path given ({documentation_path}) does not contain any documentation files."
+            )
+            return sys.exit(1)
+    except FileNotFoundError:
+        docuploader.log.error(
+            f"The documentation path given ({documentation_path}) does not exist relative to CWD."
+        )
+        return sys.exit(1)
+    except NotADirectoryError:
+        docuploader.log.error(
+            f"The documentation path given ({documentation_path}) is a file not a directory."
         )
         return sys.exit(1)
 


### PR DESCRIPTION
Check with docuploader on whether
* there is any documentation, and
* supplied path is a directory, and
* supplied path exists.

Verified locally for all covered scenarios:
```
(extension-env) dandhlee@dandhlee:~/workspace/tmp/php/test$ docuploader upload empty3 --staging-bucket test-bucket-pipeline --destination-prefix docfx- --metadata-file docs.metadata 
docuploader > The documentation path given (empty3) is a file not a directory.

(extension-env) dandhlee@dandhlee:~/workspace/tmp/php/test$ docuploader upload empty2 --staging-bucket test-bucket-pipeline --destination-prefix docfx- --metadata-file docs.metadata 
docuploader > The documentation path given (empty2) does not exist relative to CWD.

(extension-env) dandhlee@dandhlee:~/workspace/tmp/php/test$ docuploader upload empty --staging-bucket test-bucket-pipeline --destination-prefix docfx- --metadata-file docs.metadata 
docuploader > The documentation path given (empty) does not contain any documentation files.
```

Fixes #114.