### PR TITLE
fix: update storage requirement

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,7 +21,7 @@ release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     "click",
     "colorlog",
-    "google-cloud-storage<3.0.0dev",
+    "google-cloud-storage<4.0.0dev",
     "protobuf>=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 


### PR DESCRIPTION
Python Storage recently had a major bump to [3.0.0](https://github.com/googleapis/python-storage/releases/tag/v3.0.0).