### PR TITLE
fix(deps): allow Protobuf 6.x

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,8 +21,8 @@ release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     "click",
     "colorlog",
-    "google-cloud-storage<4.0.0dev",
-    "protobuf>=3.20.2,<7.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "google-cloud-storage<4.0.0",
+    "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 
 packages = setuptools.find_packages()

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ dependencies = [
     "click",
     "colorlog",
     "google-cloud-storage<4.0.0dev",
-    "protobuf>=3.20.2,<6.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "protobuf>=3.20.2,<7.0.0dev,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 
 packages = setuptools.find_packages()


### PR DESCRIPTION
See https://pypi.org/project/protobuf/6.30.0/
See https://github.com/googleapis/gapic-generator-python/pull/2347 for removing `dev` in `setup.py`