### PR TITLE
tests: update default runtime used for tests

### DIFF
--- a/noxfile.py
+++ b/noxfile.py
@@ -14,7 +14,10 @@
 
 import nox
 
-DEFAULT_PYTHON_VERSION = "3.8"
+DEFAULT_PYTHON_VERSION = "3.10"
+
+# Error if a python version is missing
+nox.options.error_on_missing_interpreters = True
 
 @nox.session(python=DEFAULT_PYTHON_VERSION)
 def blacken(session):


### PR DESCRIPTION
This PR includes the following fixes to the test environment:

- Fix presubmits following the changes in https://github.com/googleapis/testing-infra-docker/pull/491 which removes outdated setuptools which don't include a patch for CVE-2025-47273/CVE-2025-47273
- Move from Python 3.8 to Python 3.10 as the default runtime for most tests