### PR TITLE
feat: support Protobuf 7.x

### DIFF
--- a/.kokoro/trampoline_v2.sh
+++ b/.kokoro/trampoline_v2.sh
@@ -26,8 +26,8 @@
 # To run this script, first download few files from gcs to /dev/shm.
 # (/dev/shm is passed into the container as KOKORO_GFILE_DIR).
 #
-# gcloud storage cp gs://cloud-devrel-kokoro-resources/python-docs-samples/secrets_viewer_service_account.json /dev/shm
-# gcloud storage cp gs://cloud-devrel-kokoro-resources/python-docs-samples/automl_secrets.txt /dev/shm
+# gsutil cp gs://cloud-devrel-kokoro-resources/python-docs-samples/secrets_viewer_service_account.json /dev/shm
+# gsutil cp gs://cloud-devrel-kokoro-resources/python-docs-samples/automl_secrets.txt /dev/shm
 #
 # Then run the script.
 # .kokoro/trampoline_v2.sh

--- a/setup.py
+++ b/setup.py
@@ -22,7 +22,7 @@ dependencies = [
     "click",
     "colorlog",
     "google-cloud-storage<4.0.0",
-    "protobuf>=3.20.2,<7.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
+    "protobuf>=3.20.2,<8.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]
 
 packages = setuptools.find_packages()

--- a/tests/test_tar.py
+++ b/tests/test_tar.py
@@ -49,7 +49,7 @@ def test_tar(tmpdir):
     tar_destination = tmpdir / "test.tar.gz"
     tar.compress(root, tar_destination)
 
-    assert tarfile.is_tarfile(tar_destination)
+    assert tarfile.is_tarfile(str(tar_destination))
 
     decompress_destination = tmpdir / "tar_out_dir"
     pathlib.Path(decompress_destination).mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
# Support Protobuf 7.x

## Problem
The `gcp-docuploader` package had a strict dependency on `protobuf` versions less than `7.0.0`. This prevented users from upgrading to newer Protobuf 7.x releases.

## Solution
Updated the `protobuf` dependency constraint in `setup.py` to allow versions up to `<8.0.0`. This enables support for Protobuf 7.x while protecting against potential breaking changes in future major releases.

## Reviewer Notes
- A minor fix was applied to `tests/test_tar.py` to ensure compatibility with newer Python versions (like 3.12). The `tarfile.is_tarfile` function now receives a string path instead of a `LocalPath` object, which was causing failures.

Fixes #244
