### PR TITLE
chore: add google-auth dependency to setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,7 @@ release_status = 'Development Status :: 3 - Alpha'
 dependencies = [
     "click",
     "colorlog",
+    "google-auth >= 2.26.1, < 3.0.0",
     "google-cloud-storage<4.0.0",
     "protobuf>=3.20.2,<8.0.0,!=4.21.0,!=4.21.1,!=4.21.2,!=4.21.3,!=4.21.4,!=4.21.5",
 ]


### PR DESCRIPTION
Fixes https://github.com/googleapis/docuploader/issues/245

Docuploader currently depends on google-auth, which it receives as a transitive dependency from google-cloud-stroage. This PR makes the dependency explicit.